### PR TITLE
Repo hygiene: promote CODEOWNERS + PR/Issue templates to default branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Default owners for everything
+* @napier-devops-group13
+
+# CI/CD changes → lead reviewer
+.github/workflows/*  @Yamikirito
+
+# Style config → lead reviewer
+config/checkstyle/*  @Yamikirito

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,13 @@
+name: Bug
+description: Report a bug
+labels: [bug]
+body:
+- type: textarea
+  attributes:
+  label: What happened?
+- type: textarea
+  attributes:
+  label: Steps to reproduce
+- type: input
+  attributes:
+  label: Affected version/tag

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,10 @@
+name: Feature
+description: Request a feature
+labels: [feature]
+body:
+- type: textarea
+  attributes:
+  label: Problem / value
+- type: textarea
+  attributes:
+  label: Acceptance criteria

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Summary
+<!-- What and why -->
+
+## Linked issue
+Fixes #<issue-id>
+
+## Type
+- [ ] feat
+- [ ] fix
+- [ ] docs
+- [ ] test
+- [ ] ci
+- [ ] chore/refactor
+
+## Lab / Coursework alignment
+- [ ] Lab 3: CI green on JDK 24
+- [ ] Lab 4: Quality gates (Checkstyle + SpotBugs)
+- [ ] Lab 5–6: Data layer & endpoints
+- [ ] Lab 7: Tests + coverage (JaCoCo)
+- [ ] Lab 8: Docker / Compose
+- [ ] CR tagging (e.g., v0.x.y)
+
+## Checks
+- [ ] CI passed (`build-java24`, `coverage-java21`, `docker-build`)
+- [ ] Coverage not reduced
+- [ ] Style/SpotBugs clean
+- [ ] Docs/README updated if needed


### PR DESCRIPTION
Move CODEOWNERS + PR/Issue templates so GitHub uses them automatically.